### PR TITLE
protobuf: Fix fetcher failure for rocko.

### DIFF
--- a/meta-yp/meta-openembedded/meta-oe/recipes-devtools/protobuf/protobuf_3.4.1.bb
+++ b/meta-yp/meta-openembedded/meta-oe/recipes-devtools/protobuf/protobuf_3.4.1.bb
@@ -18,7 +18,7 @@ SRCREV = "b04e5cba356212e4e8c66c61bbe0c3a20537c5b9"
 
 PV = "3.4.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/google/protobuf.git;branch=3.4.x"
+SRC_URI = "git://github.com/google/protobuf.git"
 
 EXTRA_OECONF += " --with-protoc=echo"
 


### PR DESCRIPTION
The 3.4.x branch disappered from the github repo. Remviing the branch
entry from SRC_URI allows the fetch to succeed. Rocko is the only release
that has this issue. Sumo and later have 3.5.x.

patch on oepnembedded repo : 
    http://git.openembedded.org/meta-openembedded/commit/?h=rocko&id=352531015014d1957d6444d114f4451e241c4d23