### PR TITLE
glibc: Check /etc/ld.so.conf.d/*.conf by default

### DIFF
--- a/meta-core/meta-base/recipes-core/glibc/glibc/etc/ld.so.conf
+++ b/meta-core/meta-base/recipes-core/glibc/glibc/etc/ld.so.conf
@@ -1,0 +1,1 @@
+include /etc/ld.so.conf.d/*.conf


### PR DESCRIPTION
The expected modern behavior for dealing with adding ld.so.conf entries
is to add a file to /etc/ld.so.conf.d/.  In order to do this, ld.so.conf
needs to explicitly include that /etc/ld.so.conf.d/*.conf.  Make it so.

refer to https://git.yoctoproject.org/cgit/cgit.cgi/poky-contrib/commit/meta/recipes-core/glibc/glibc/etc/ld.so.conf?id=d7fc3484ef676cd420092193e341c84731967614